### PR TITLE
Update generated interfaces to address deprecation changes

### DIFF
--- a/src/cursor_kind/pkg.generated.mbti
+++ b/src/cursor_kind/pkg.generated.mbti
@@ -1,0 +1,605 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/clang/cursor_kind"
+
+// Values
+pub const AddrLabelExpr : Int = 120
+
+pub const AlignedAttr : Int = 441
+
+pub const AnnotateAttr : Int = 406
+
+pub const ArraySubscriptExpr : Int = 113
+
+pub const AsmLabelAttr : Int = 407
+
+pub const AsmStmt : Int = 215
+
+pub const BinaryOperator : Int = 114
+
+pub const BlockExpr : Int = 105
+
+pub const BreakStmt : Int = 213
+
+pub const BuiltinBitCastExpr : Int = 280
+
+pub const CStyleCastExpr : Int = 117
+
+pub const CUDAConstantAttr : Int = 412
+
+pub const CUDADeviceAttr : Int = 413
+
+pub const CUDAGlobalAttr : Int = 414
+
+pub const CUDAHostAttr : Int = 415
+
+pub const CUDASharedAttr : Int = 416
+
+pub const CXXAccessSpecifier : Int = 39
+
+pub const CXXAddrspaceCastExpr : Int = 152
+
+pub const CXXBaseSpecifier : Int = 44
+
+pub const CXXBoolLiteralExpr : Int = 130
+
+pub const CXXCatchStmt : Int = 223
+
+pub const CXXConstCastExpr : Int = 127
+
+pub const CXXDeleteExpr : Int = 135
+
+pub const CXXDynamicCastExpr : Int = 125
+
+pub const CXXFinalAttr : Int = 404
+
+pub const CXXForRangeStmt : Int = 225
+
+pub const CXXFunctionalCastExpr : Int = 128
+
+pub const CXXMethod : Int = 21
+
+pub const CXXNewExpr : Int = 134
+
+pub const CXXNullPtrLiteralExpr : Int = 131
+
+pub const CXXOverrideAttr : Int = 405
+
+pub const CXXParenListInitExpr : Int = 155
+
+pub const CXXReinterpretCastExpr : Int = 126
+
+pub const CXXStaticCastExpr : Int = 124
+
+pub const CXXThisExpr : Int = 132
+
+pub const CXXThrowExpr : Int = 133
+
+pub const CXXTryStmt : Int = 224
+
+pub const CXXTypeidExpr : Int = 129
+
+pub const CallExpr : Int = 103
+
+pub const CaseStmt : Int = 203
+
+pub const CharacterLiteral : Int = 110
+
+pub const ClassDecl : Int = 4
+
+pub const ClassTemplate : Int = 31
+
+pub const ClassTemplatePartialSpecialization : Int = 32
+
+pub const CompoundAssignOperator : Int = 115
+
+pub const CompoundLiteralExpr : Int = 118
+
+pub const CompoundStmt : Int = 202
+
+pub const ConceptDecl : Int = 604
+
+pub const ConceptSpecializationExpr : Int = 153
+
+pub const ConditionalOperator : Int = 116
+
+pub const ConstAttr : Int = 410
+
+pub const Constructor : Int = 24
+
+pub const ContinueStmt : Int = 212
+
+pub const ConvergentAttr : Int = 438
+
+pub const ConversionFunction : Int = 26
+
+pub const DLLExport : Int = 418
+
+pub const DLLImport : Int = 419
+
+pub const DeclRefExpr : Int = 101
+
+pub const DeclStmt : Int = 231
+
+pub const DefaultStmt : Int = 204
+
+pub const Destructor : Int = 25
+
+pub const DoStmt : Int = 208
+
+pub const EnumConstantDecl : Int = 7
+
+pub const EnumDecl : Int = 5
+
+pub const FieldDecl : Int = 6
+
+pub const FirstAttr : Int = 400
+
+pub const FirstDecl : Int = 1
+
+pub const FirstExpr : Int = 100
+
+pub const FirstExtraDecl : Int = 600
+
+pub const FirstInvalid : Int = 70
+
+pub const FirstPreprocessing : Int = 500
+
+pub const FirstRef : Int = 40
+
+pub const FirstStmt : Int = 200
+
+pub const FixedPointLiteral : Int = 149
+
+pub const FlagEnum : Int = 437
+
+pub const FloatingLiteral : Int = 107
+
+pub const ForStmt : Int = 209
+
+pub const FriendDecl : Int = 603
+
+pub const FunctionDecl : Int = 8
+
+pub const FunctionTemplate : Int = 30
+
+pub const GCCAsmStmt : Int = 215
+
+pub const GNUNullExpr : Int = 123
+
+pub const GenericSelectionExpr : Int = 122
+
+pub const GotoStmt : Int = 210
+
+pub const IBActionAttr : Int = 401
+
+pub const IBOutletAttr : Int = 402
+
+pub const IBOutletCollectionAttr : Int = 403
+
+pub const IfStmt : Int = 205
+
+pub const ImaginaryLiteral : Int = 108
+
+pub const InclusionDirective : Int = 503
+
+pub const IndirectGotoStmt : Int = 211
+
+pub const InitListExpr : Int = 119
+
+pub const IntegerLiteral : Int = 106
+
+pub const InvalidCode : Int = 73
+
+pub const InvalidFile : Int = 70
+
+pub const LabelRef : Int = 48
+
+pub const LabelStmt : Int = 201
+
+pub const LambdaExpr : Int = 144
+
+pub const LastAttr : Int = 441
+
+pub const LastDecl : Int = 39
+
+pub const LastExpr : Int = 155
+
+pub const LastExtraDecl : Int = 604
+
+pub const LastInvalid : Int = 73
+
+pub const LastPreprocessing : Int = 503
+
+pub const LastRef : Int = 50
+
+pub const LastStmt : Int = 306
+
+pub const LinkageSpec : Int = 23
+
+pub const MSAsmStmt : Int = 229
+
+pub const MacroDefinition : Int = 501
+
+pub const MacroExpansion : Int = 502
+
+pub const MacroInstantiation : Int = 502
+
+pub const MemberRef : Int = 47
+
+pub const MemberRefExpr : Int = 102
+
+pub const ModuleImportDecl : Int = 600
+
+pub const NSConsumed : Int = 424
+
+pub const NSConsumesSelf : Int = 423
+
+pub const NSReturnsAutoreleased : Int = 422
+
+pub const NSReturnsNotRetained : Int = 421
+
+pub const NSReturnsRetained : Int = 420
+
+pub const Namespace : Int = 22
+
+pub const NamespaceAlias : Int = 33
+
+pub const NamespaceRef : Int = 46
+
+pub const NoDeclFound : Int = 71
+
+pub const NoDuplicateAttr : Int = 411
+
+pub const NonTypeTemplateParameter : Int = 28
+
+pub const NotImplemented : Int = 72
+
+pub const NullStmt : Int = 230
+
+pub const OMPArraySectionExpr : Int = 147
+
+pub const OMPArrayShapingExpr : Int = 150
+
+pub const OMPAtomicDirective : Int = 249
+
+pub const OMPBarrierDirective : Int = 244
+
+pub const OMPCancelDirective : Int = 256
+
+pub const OMPCancellationPointDirective : Int = 255
+
+pub const OMPCanonicalLoop : Int = 289
+
+pub const OMPCriticalDirective : Int = 242
+
+pub const OMPDepobjDirective : Int = 286
+
+pub const OMPDispatchDirective : Int = 291
+
+pub const OMPDistributeDirective : Int = 260
+
+pub const OMPDistributeParallelForDirective : Int = 266
+
+pub const OMPDistributeParallelForSimdDirective : Int = 267
+
+pub const OMPDistributeSimdDirective : Int = 268
+
+pub const OMPErrorDirective : Int = 305
+
+pub const OMPFlushDirective : Int = 246
+
+pub const OMPForDirective : Int = 234
+
+pub const OMPForSimdDirective : Int = 250
+
+pub const OMPGenericLoopDirective : Int = 295
+
+pub const OMPInteropDirective : Int = 290
+
+pub const OMPIteratorExpr : Int = 151
+
+pub const OMPMaskedDirective : Int = 292
+
+pub const OMPMaskedTaskLoopDirective : Int = 301
+
+pub const OMPMaskedTaskLoopSimdDirective : Int = 302
+
+pub const OMPMasterDirective : Int = 241
+
+pub const OMPMasterTaskLoopDirective : Int = 281
+
+pub const OMPMasterTaskLoopSimdDirective : Int = 283
+
+pub const OMPMetaDirective : Int = 294
+
+pub const OMPOrderedDirective : Int = 248
+
+pub const OMPParallelDirective : Int = 232
+
+pub const OMPParallelForDirective : Int = 238
+
+pub const OMPParallelForSimdDirective : Int = 251
+
+pub const OMPParallelGenericLoopDirective : Int = 298
+
+pub const OMPParallelMaskedDirective : Int = 300
+
+pub const OMPParallelMaskedTaskLoopDirective : Int = 303
+
+pub const OMPParallelMaskedTaskLoopSimdDirective : Int = 304
+
+pub const OMPParallelMasterDirective : Int = 285
+
+pub const OMPParallelMasterTaskLoopDirective : Int = 282
+
+pub const OMPParallelMasterTaskLoopSimdDirective : Int = 284
+
+pub const OMPParallelSectionsDirective : Int = 239
+
+pub const OMPScanDirective : Int = 287
+
+pub const OMPScopeDirective : Int = 306
+
+pub const OMPSectionDirective : Int = 236
+
+pub const OMPSectionsDirective : Int = 235
+
+pub const OMPSimdDirective : Int = 233
+
+pub const OMPSingleDirective : Int = 237
+
+pub const OMPTargetDataDirective : Int = 257
+
+pub const OMPTargetDirective : Int = 252
+
+pub const OMPTargetEnterDataDirective : Int = 261
+
+pub const OMPTargetExitDataDirective : Int = 262
+
+pub const OMPTargetParallelDirective : Int = 263
+
+pub const OMPTargetParallelForDirective : Int = 264
+
+pub const OMPTargetParallelForSimdDirective : Int = 269
+
+pub const OMPTargetParallelGenericLoopDirective : Int = 299
+
+pub const OMPTargetSimdDirective : Int = 270
+
+pub const OMPTargetTeamsDirective : Int = 275
+
+pub const OMPTargetTeamsDistributeDirective : Int = 276
+
+pub const OMPTargetTeamsDistributeParallelForDirective : Int = 277
+
+pub const OMPTargetTeamsDistributeParallelForSimdDirective : Int = 278
+
+pub const OMPTargetTeamsDistributeSimdDirective : Int = 279
+
+pub const OMPTargetTeamsGenericLoopDirective : Int = 297
+
+pub const OMPTargetUpdateDirective : Int = 265
+
+pub const OMPTaskDirective : Int = 240
+
+pub const OMPTaskLoopDirective : Int = 258
+
+pub const OMPTaskLoopSimdDirective : Int = 259
+
+pub const OMPTaskgroupDirective : Int = 254
+
+pub const OMPTaskwaitDirective : Int = 245
+
+pub const OMPTaskyieldDirective : Int = 243
+
+pub const OMPTeamsDirective : Int = 253
+
+pub const OMPTeamsDistributeDirective : Int = 271
+
+pub const OMPTeamsDistributeParallelForDirective : Int = 274
+
+pub const OMPTeamsDistributeParallelForSimdDirective : Int = 273
+
+pub const OMPTeamsDistributeSimdDirective : Int = 272
+
+pub const OMPTeamsGenericLoopDirective : Int = 296
+
+pub const OMPTileDirective : Int = 288
+
+pub const OMPUnrollDirective : Int = 293
+
+pub const ObjCAtCatchStmt : Int = 217
+
+pub const ObjCAtFinallyStmt : Int = 218
+
+pub const ObjCAtSynchronizedStmt : Int = 220
+
+pub const ObjCAtThrowStmt : Int = 219
+
+pub const ObjCAtTryStmt : Int = 216
+
+pub const ObjCAutoreleasePoolStmt : Int = 221
+
+pub const ObjCAvailabilityCheckExpr : Int = 148
+
+pub const ObjCBoolLiteralExpr : Int = 145
+
+pub const ObjCBoxable : Int = 436
+
+pub const ObjCBridgedCastExpr : Int = 141
+
+pub const ObjCCategoryDecl : Int = 12
+
+pub const ObjCCategoryImplDecl : Int = 19
+
+pub const ObjCClassMethodDecl : Int = 17
+
+pub const ObjCClassRef : Int = 42
+
+pub const ObjCDesignatedInitializer : Int = 434
+
+pub const ObjCDynamicDecl : Int = 38
+
+pub const ObjCEncodeExpr : Int = 138
+
+pub const ObjCException : Int = 425
+
+pub const ObjCExplicitProtocolImpl : Int = 433
+
+pub const ObjCForCollectionStmt : Int = 222
+
+pub const ObjCImplementationDecl : Int = 18
+
+pub const ObjCIndependentClass : Int = 427
+
+pub const ObjCInstanceMethodDecl : Int = 16
+
+pub const ObjCInterfaceDecl : Int = 11
+
+pub const ObjCIvarDecl : Int = 15
+
+pub const ObjCMessageExpr : Int = 104
+
+pub const ObjCNSObject : Int = 426
+
+pub const ObjCPreciseLifetime : Int = 428
+
+pub const ObjCPropertyDecl : Int = 14
+
+pub const ObjCProtocolDecl : Int = 13
+
+pub const ObjCProtocolExpr : Int = 140
+
+pub const ObjCProtocolRef : Int = 41
+
+pub const ObjCRequiresSuper : Int = 430
+
+pub const ObjCReturnsInnerPointer : Int = 429
+
+pub const ObjCRootClass : Int = 431
+
+pub const ObjCRuntimeVisible : Int = 435
+
+pub const ObjCSelectorExpr : Int = 139
+
+pub const ObjCSelfExpr : Int = 146
+
+pub const ObjCStringLiteral : Int = 137
+
+pub const ObjCSubclassingRestricted : Int = 432
+
+pub const ObjCSuperClassRef : Int = 40
+
+pub const ObjCSynthesizeDecl : Int = 37
+
+pub const OverloadCandidate : Int = 700
+
+pub const OverloadedDeclRef : Int = 49
+
+pub const PackExpansionExpr : Int = 142
+
+pub const PackedAttr : Int = 408
+
+pub const ParenExpr : Int = 111
+
+pub const ParmDecl : Int = 10
+
+pub const PreprocessingDirective : Int = 500
+
+pub const PureAttr : Int = 409
+
+pub const RequiresExpr : Int = 154
+
+pub const ReturnStmt : Int = 214
+
+pub const SEHExceptStmt : Int = 227
+
+pub const SEHFinallyStmt : Int = 228
+
+pub const SEHLeaveStmt : Int = 247
+
+pub const SEHTryStmt : Int = 226
+
+pub const SizeOfPackExpr : Int = 143
+
+pub const StaticAssert : Int = 602
+
+pub const StmtExpr : Int = 121
+
+pub const StringLiteral : Int = 109
+
+pub const StructDecl : Int = 2
+
+pub const SwitchStmt : Int = 206
+
+pub const TemplateRef : Int = 45
+
+pub const TemplateTemplateParameter : Int = 29
+
+pub const TemplateTypeParameter : Int = 27
+
+pub const TranslationUnit : Int = 350
+
+pub const TypeAliasDecl : Int = 36
+
+pub const TypeAliasTemplateDecl : Int = 601
+
+pub const TypeRef : Int = 43
+
+pub const TypedefDecl : Int = 20
+
+pub const UnaryExpr : Int = 136
+
+pub const UnaryOperator : Int = 112
+
+pub const UnexposedAttr : Int = 400
+
+pub const UnexposedDecl : Int = 1
+
+pub const UnexposedExpr : Int = 100
+
+pub const UnexposedStmt : Int = 200
+
+pub const UnionDecl : Int = 3
+
+pub const UsingDeclaration : Int = 35
+
+pub const UsingDirective : Int = 34
+
+pub const VarDecl : Int = 9
+
+pub const VariableRef : Int = 50
+
+pub const VisibilityAttr : Int = 417
+
+pub const WarnUnusedAttr : Int = 439
+
+pub const WarnUnusedResultAttr : Int = 440
+
+pub const WhileStmt : Int = 207
+
+pub fn is_attribute(Int) -> Bool
+
+pub fn is_declaration(Int) -> Bool
+
+pub fn is_expression(Int) -> Bool
+
+pub fn is_preprocessing(Int) -> Bool
+
+pub fn is_reference(Int) -> Bool
+
+pub fn is_statement(Int) -> Bool
+
+pub fn is_translationUnit(Int) -> Bool
+
+pub fn is_unexposed(Int) -> Bool
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+pub type CursorKind = Int
+
+// Traits
+

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -1,0 +1,202 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/clang"
+
+// Values
+
+// Errors
+type ParseError
+pub impl Eq for ParseError
+pub impl Show for ParseError
+
+// Types and methods
+pub(all) enum AvailabilityKind {
+  Available
+  Deprecated
+  NotAvailable
+  NotAccessible
+}
+pub impl Eq for AvailabilityKind
+pub impl Show for AvailabilityKind
+
+pub(all) enum CXX_AccessSpecifier {
+  InvalidAccessSpecifier
+  Public
+  Protected
+  Private
+}
+pub impl Eq for CXX_AccessSpecifier
+pub impl Show for CXX_AccessSpecifier
+
+pub(all) enum CallingConv {
+  Default
+  C
+  X86StdCall
+  X86FastCall
+  X86ThisCall
+  X86Pascal
+  AAPCS
+  AAPCS_VFP
+  X86RegCall
+  IntelOclBicc
+  X86_64Win64
+  X86_64SysV
+  X86VectorCall
+  Swift
+  PreserveMost
+  PreserveAll
+  AArch64VectorCall
+  SwiftAsync
+  AArch64SVEPCS
+  M68kRTD
+  Invalid
+  CXCallingConv_Unexposed
+}
+pub impl Eq for CallingConv
+pub impl Show for CallingConv
+
+type Cursor
+pub fn Cursor::availability(Self) -> LinkageKind
+pub fn Cursor::canonical(Self) -> Self
+pub fn Cursor::cxx_access_specifier(Self) -> CXX_AccessSpecifier
+pub fn Cursor::display_name(Self) -> Bytes
+pub fn Cursor::enum_constant_decl_unsigned_value(Self) -> UInt64
+pub fn Cursor::enum_constant_decl_value(Self) -> Int64
+pub fn Cursor::enum_decl_integer_type(Self) -> Type
+pub fn Cursor::extent(Self) -> SourceRange
+pub fn Cursor::is_function_inlined(Self) -> Bool
+pub fn Cursor::is_macro_builtin(Self) -> Bool
+pub fn Cursor::is_macro_function_like(Self) -> Bool
+pub fn Cursor::is_null(Self) -> Bool
+pub fn Cursor::kind(Self) -> Int
+pub fn Cursor::kind_spelling(Int) -> Bytes
+pub fn Cursor::language(Self) -> LanguageKind
+pub fn Cursor::lexical_parent(Self) -> Self
+pub fn Cursor::linkage(Self) -> LinkageKind
+pub fn Cursor::null() -> Self
+pub fn Cursor::overloaded_decls(Self, Int) -> Self
+pub fn Cursor::overloaded_decls_num(Self) -> Int
+pub fn Cursor::semantic_parent(Self) -> Self
+pub fn Cursor::source_location(Self) -> SourceLocation
+pub fn Cursor::spelling(Self) -> Bytes
+pub fn Cursor::storage_class(Self) -> StorageClass
+pub fn Cursor::type_(Self) -> Type
+pub fn Cursor::typedef_decl_underlying_type(Self) -> Type
+pub fn Cursor::visibility(Self) -> LinkageKind
+pub impl Eq for Cursor
+
+pub(all) enum ErrorCode {
+  Success
+  Failure
+  Crashed
+  InvalidArguments
+  ASTReadError
+}
+pub impl Eq for ErrorCode
+pub impl Show for ErrorCode
+
+type Index
+pub fn Index::new(Bool, Bool) -> Self
+pub fn Index::parse(Self, Bytes, FixedArray[Bytes], TranslationUnit_Flags) -> TranslationUnit raise ParseError
+
+pub(all) enum LanguageKind {
+  Invalid
+  C
+  ObjC
+  CPlusPlus
+}
+pub impl Eq for LanguageKind
+pub impl Show for LanguageKind
+
+pub(all) enum LinkageKind {
+  Invalid
+  NoLinkage
+  Internal
+  UniqueExternal
+  External
+}
+pub impl Eq for LinkageKind
+pub impl Show for LinkageKind
+
+type SourceLocation
+pub fn SourceLocation::null() -> Self
+pub impl Eq for SourceLocation
+
+type SourceRange
+pub impl Eq for SourceRange
+
+type StorageClass
+pub impl Eq for StorageClass
+pub impl Show for StorageClass
+
+type TargetInfo
+pub fn TargetInfo::pointer_width(Self) -> Int
+pub fn TargetInfo::triple(Self) -> Bytes
+
+type Token
+pub fn Token::spelling(Self) -> Bytes
+
+type TranslationUnit
+pub fn TranslationUnit::cursor(Self) -> Cursor
+pub fn TranslationUnit::target_info(Self) -> TargetInfo
+pub fn TranslationUnit::tokenize(Self, SourceRange) -> FixedArray[Token]
+
+pub enum TranslationUnit_Flags {
+  None
+  DetailedPreprocessingRecord
+  Incomplete
+  PrecompiledPreamble
+  CacheCompletionResults
+  ForSerialization
+  CXXChainedPCH
+  SkipFunctionBodies
+  IncludeBriefCommentsInCodeCompletion
+  CreatePreambleOnFirstParse
+  KeepGoing
+  SingleFileParse
+  LimitSkipFunctionBodiesToPreamble
+  IncludeAttributedTypes
+  VisitImplicitAttributes
+  IgnoreNonErrorsFromIncludedFiles
+  RetainExcludedConditionalBlocks
+}
+pub impl BitOr for TranslationUnit_Flags
+pub impl Eq for TranslationUnit_Flags
+pub impl Show for TranslationUnit_Flags
+
+type Type
+pub fn Type::address_space(Self) -> Int
+pub fn Type::argument(Self, Int) -> Self
+pub fn Type::arity(Self) -> Int
+pub fn Type::calling_conv(Self) -> CallingConv
+pub fn Type::canonical(Self) -> Self
+pub fn Type::is_const_qualified(Self) -> Bool
+pub fn Type::is_restrict_qualified(Self) -> Bool
+pub fn Type::is_volatile_qualified(Self) -> Bool
+pub fn Type::kind(Self) -> Int
+pub fn Type::kind_spelling(Int) -> Bytes
+pub fn Type::offsetof(Self, Bytes) -> Int64
+pub fn Type::pointee(Self) -> Self
+pub fn Type::result(Self) -> Self
+pub fn Type::sizeof(Self) -> Int64
+pub fn Type::spelling(Self) -> Bytes
+pub fn Type::type_declaration(Self) -> Cursor
+pub fn Type::typedef_name(Self) -> Byte
+pub fn Type::unqualified(Self) -> Self
+pub impl Eq for Type
+
+pub(all) enum VisibilityKind {
+  Invalid
+  Hidden
+  Protected
+  Default
+}
+pub impl Eq for VisibilityKind
+pub impl Show for VisibilityKind
+
+// Type aliases
+pub type CursorKind = Int
+
+pub type TypeKind = Int
+
+// Traits
+

--- a/src/type_kind/pkg.generated.mbti
+++ b/src/type_kind/pkg.generated.mbti
@@ -1,0 +1,265 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/clang/type_kind"
+
+// Values
+pub const Accum : Int = 34
+
+pub const Atomic : Int = 177
+
+pub const Attributed : Int = 163
+
+pub const Auto : Int = 118
+
+pub const BFloat16 : Int = 39
+
+pub const BTFTagAttributed : Int = 178
+
+pub const BlockPointer : Int = 102
+
+pub const Bool : Int = 3
+
+pub const Char16 : Int = 6
+
+pub const Char32 : Int = 7
+
+pub const Char_S : Int = 13
+
+pub const Char_U : Int = 4
+
+pub const Complex : Int = 100
+
+pub const ConstantArray : Int = 112
+
+pub const Dependent : Int = 26
+
+pub const DependentSizedArray : Int = 116
+
+pub const Double : Int = 22
+
+pub const Elaborated : Int = 119
+
+pub const Enum : Int = 106
+
+pub const ExtVector : Int = 176
+
+pub const FirstBuiltin : Int = 2
+
+pub const Float : Int = 21
+
+pub const Float128 : Int = 30
+
+pub const Float16 : Int = 32
+
+pub const FunctionNoProto : Int = 110
+
+pub const FunctionProto : Int = 111
+
+pub const Half : Int = 31
+
+pub const Ibm128 : Int = 40
+
+pub const IncompleteArray : Int = 114
+
+pub const Int : Int = 17
+
+pub const Int128 : Int = 20
+
+pub const Invalid : Int = 0
+
+pub const LValueReference : Int = 103
+
+pub const LastBuiltin : Int = 40
+
+pub const Long : Int = 18
+
+pub const LongAccum : Int = 35
+
+pub const LongDouble : Int = 23
+
+pub const LongLong : Int = 19
+
+pub const MemberPointer : Int = 117
+
+pub const NullPtr : Int = 24
+
+pub const OCLEvent : Int = 158
+
+pub const OCLImage1dArrayRO : Int = 122
+
+pub const OCLImage1dArrayRW : Int = 146
+
+pub const OCLImage1dArrayWO : Int = 134
+
+pub const OCLImage1dBufferRO : Int = 123
+
+pub const OCLImage1dBufferRW : Int = 147
+
+pub const OCLImage1dBufferWO : Int = 135
+
+pub const OCLImage1dRO : Int = 121
+
+pub const OCLImage1dRW : Int = 145
+
+pub const OCLImage1dWO : Int = 133
+
+pub const OCLImage2dArrayDepthRO : Int = 127
+
+pub const OCLImage2dArrayDepthRW : Int = 151
+
+pub const OCLImage2dArrayDepthWO : Int = 139
+
+pub const OCLImage2dArrayMSAADepthRO : Int = 131
+
+pub const OCLImage2dArrayMSAADepthRW : Int = 155
+
+pub const OCLImage2dArrayMSAADepthWO : Int = 143
+
+pub const OCLImage2dArrayMSAARO : Int = 129
+
+pub const OCLImage2dArrayMSAARW : Int = 153
+
+pub const OCLImage2dArrayMSAAWO : Int = 141
+
+pub const OCLImage2dArrayRO : Int = 125
+
+pub const OCLImage2dArrayRW : Int = 149
+
+pub const OCLImage2dArrayWO : Int = 137
+
+pub const OCLImage2dDepthRO : Int = 126
+
+pub const OCLImage2dDepthRW : Int = 150
+
+pub const OCLImage2dDepthWO : Int = 138
+
+pub const OCLImage2dMSAADepthRO : Int = 130
+
+pub const OCLImage2dMSAADepthRW : Int = 154
+
+pub const OCLImage2dMSAADepthWO : Int = 142
+
+pub const OCLImage2dMSAARO : Int = 128
+
+pub const OCLImage2dMSAARW : Int = 152
+
+pub const OCLImage2dMSAAWO : Int = 140
+
+pub const OCLImage2dRO : Int = 124
+
+pub const OCLImage2dRW : Int = 148
+
+pub const OCLImage2dWO : Int = 136
+
+pub const OCLImage3dRO : Int = 132
+
+pub const OCLImage3dRW : Int = 156
+
+pub const OCLImage3dWO : Int = 144
+
+pub const OCLIntelSubgroupAVCImeDualRefStreamin : Int = 175
+
+pub const OCLIntelSubgroupAVCImeDualReferenceStreamin : Int = 175
+
+pub const OCLIntelSubgroupAVCImePayload : Int = 165
+
+pub const OCLIntelSubgroupAVCImeResult : Int = 169
+
+pub const OCLIntelSubgroupAVCImeResultDualRefStreamout : Int = 173
+
+pub const OCLIntelSubgroupAVCImeResultDualReferenceStreamout : Int = 173
+
+pub const OCLIntelSubgroupAVCImeResultSingleRefStreamout : Int = 172
+
+pub const OCLIntelSubgroupAVCImeResultSingleReferenceStreamout : Int = 172
+
+pub const OCLIntelSubgroupAVCImeSingleRefStreamin : Int = 174
+
+pub const OCLIntelSubgroupAVCImeSingleReferenceStreamin : Int = 174
+
+pub const OCLIntelSubgroupAVCMcePayload : Int = 164
+
+pub const OCLIntelSubgroupAVCMceResult : Int = 168
+
+pub const OCLIntelSubgroupAVCRefPayload : Int = 166
+
+pub const OCLIntelSubgroupAVCRefResult : Int = 170
+
+pub const OCLIntelSubgroupAVCSicPayload : Int = 167
+
+pub const OCLIntelSubgroupAVCSicResult : Int = 171
+
+pub const OCLQueue : Int = 159
+
+pub const OCLReserveID : Int = 160
+
+pub const OCLSampler : Int = 157
+
+pub const ObjCClass : Int = 28
+
+pub const ObjCId : Int = 27
+
+pub const ObjCInterface : Int = 108
+
+pub const ObjCObject : Int = 161
+
+pub const ObjCObjectPointer : Int = 109
+
+pub const ObjCSel : Int = 29
+
+pub const ObjCTypeParam : Int = 162
+
+pub const Overload : Int = 25
+
+pub const Pipe : Int = 120
+
+pub const Pointer : Int = 101
+
+pub const RValueReference : Int = 104
+
+pub const Record : Int = 105
+
+pub const SChar : Int = 14
+
+pub const Short : Int = 16
+
+pub const ShortAccum : Int = 33
+
+pub const Typedef : Int = 107
+
+pub const UAccum : Int = 37
+
+pub const UChar : Int = 5
+
+pub const UInt : Int = 9
+
+pub const UInt128 : Int = 12
+
+pub const ULong : Int = 10
+
+pub const ULongAccum : Int = 38
+
+pub const ULongLong : Int = 11
+
+pub const UShort : Int = 8
+
+pub const UShortAccum : Int = 36
+
+pub const Unexposed : Int = 1
+
+pub const VariableArray : Int = 115
+
+pub const Vector : Int = 113
+
+pub const Void : Int = 2
+
+pub const WChar : Int = 15
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+pub type TypeKind = Int
+
+// Traits
+


### PR DESCRIPTION
## Summary
- Regenerated MoonBit package interfaces to align with recent API/deprecation updates
- Updated generated `.mbti` files for cursor_kind, type_kind, and root package

## Rationale
These updates address deprecation warnings/errors by syncing generated interfaces with the current source definitions, which is required after migration-related changes (e.g., Iterator/Iterator2 updates).

## Implementation Notes
- Regeneration was performed via the standard MoonBit tooling (`moon info`) to reflect current public APIs
- No runtime logic changes; updates are confined to generated interface files